### PR TITLE
Fix infinite loop fetching user data

### DIFF
--- a/src/UI/components/navigationBar/navigation.bar.tsx
+++ b/src/UI/components/navigationBar/navigation.bar.tsx
@@ -22,15 +22,15 @@ export function NavBar() {
     useEffect(() => {
         const fetchUser = async () => {
             try {
-              const user = await userRepository.getMe()
-              dispatch({ type: "UPDATE_USER", payload: user })
+                const user = await userRepository.getMe()
+                dispatch({ type: "UPDATE_USER", payload: user })
             } catch (error) {
-              addAlert({ severity: 'error', message: "Erreur lors de la récupération de l'utilisateur" })
+                addAlert({ severity: 'error', message: "Erreur lors de la récupération de l'utilisateur" })
             }
-          }
+        }
 
         fetchUser()
-    }, [state.currentUser])
+    }, [])
 
     return (
         <div className="w-[260px] h-full bg-slate-700 flex flex-col px-3 pb-2">


### PR DESCRIPTION
## Summary
- avoid infinite loop while retrieving current user in the navigation bar

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684007cf4100832a83c02cf9aa950efc