### PR TITLE
Refactor button enums

### DIFF
--- a/src/UI/components/buttons/custom.button.tsx
+++ b/src/UI/components/buttons/custom.button.tsx
@@ -3,17 +3,8 @@ import { ReactNode } from 'react';
 import styled, { css } from "styled-components"
 import tw from 'twin.macro'
 
-export enum TypeButton {
-    "PRIMARY",
-    "SECONDARY",
-    "TEXT"
-}
-
-export enum WidthButton {
-    "LARGE",
-    "MEDIUM",
-    "SMALL"
-}
+import { TypeButton, WidthButton } from "./custom.button.types";
+export { TypeButton, WidthButton };
 
 interface CustomButtonProps {
     inputType?: "submit" | "reset" | "button"| undefined

--- a/src/UI/components/buttons/custom.button.types.ts
+++ b/src/UI/components/buttons/custom.button.types.ts
@@ -1,0 +1,11 @@
+export enum TypeButton {
+    PRIMARY = "PRIMARY",
+    SECONDARY = "SECONDARY",
+    TEXT = "TEXT",
+}
+
+export enum WidthButton {
+    LARGE = "LARGE",
+    MEDIUM = "MEDIUM",
+    SMALL = "SMALL",
+}


### PR DESCRIPTION
## Summary
- extract button enums to `custom.button.types.ts`
- import and re-export enums in `custom.button.tsx`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684ae8f00fd0832a893b9a2d2bddabc6