### PR TITLE
Refactor modal position enum

### DIFF
--- a/src/UI/components/ingredientsLister/children/ingredients.modal.creation.ingredient.tsx
+++ b/src/UI/components/ingredientsLister/children/ingredients.modal.creation.ingredient.tsx
@@ -1,4 +1,5 @@
-import { Modal, PositionModal } from "../../modals/modal"
+import { Modal } from "../../modals/modal"
+import { PositionModal } from "../../modals/modal.types"
 import ModalInput from "../../../style/modal.input.style"
 import { Ingredient } from "../../../../data/models/ingredient.model"
 import { NavigationModal, useIngredientsListerDispatchContext, useIngredientsListerStateContext } from "../ingredients.lister.reducer"

--- a/src/UI/components/ingredientsLister/children/ingredients.modal.home.tsx
+++ b/src/UI/components/ingredientsLister/children/ingredients.modal.home.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useEffect } from "react"
-import { Modal, PositionModal } from "../../modals/modal"
+import { Modal } from "../../modals/modal"
+import { PositionModal } from "../../modals/modal.types"
 import ModalInput from "../../../style/modal.input.style"
 import { Ingredient } from "../../../../data/models/ingredient.model"
 import { NavigationModal, useIngredientsListerDispatchContext, useIngredientsListerStateContext } from "../ingredients.lister.reducer"

--- a/src/UI/components/ingredientsLister/children/ingredients.modal.tsx
+++ b/src/UI/components/ingredientsLister/children/ingredients.modal.tsx
@@ -1,4 +1,5 @@
-import { Modal, PositionModal } from "../../modals/modal"
+import { Modal } from "../../modals/modal"
+import { PositionModal } from "../../modals/modal.types"
 import ModalInput from "../../../style/modal.input.style"
 import { toCapitalize } from '../../../../applications/extensions/string+extension';
 import { Ingredient, IngredientUnity } from "../../../../data/models/ingredient.model";

--- a/src/UI/components/modals/modal.tsx
+++ b/src/UI/components/modals/modal.tsx
@@ -1,9 +1,5 @@
 import { ReactNode } from "react"
-
-export enum PositionModal {
-    TOP,
-    BOTTOM
-}
+import { PositionModal } from "./modal.types"
 
 interface ModalProps {
     position?: PositionModal

--- a/src/UI/components/modals/modal.types.ts
+++ b/src/UI/components/modals/modal.types.ts
@@ -1,0 +1,4 @@
+export enum PositionModal {
+    TOP,
+    BOTTOM
+}


### PR DESCRIPTION
## Summary
- define `PositionModal` in its own file
- use the new enum in `modal.tsx`
- update ingredient modals to import `PositionModal` from `modal.types`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aed178c78832a9142267226ed3a47