### PR TITLE
Fix unused import and effect deps

### DIFF
--- a/src/UI/pages/cards/edit.card.modal.tsx
+++ b/src/UI/pages/cards/edit.card.modal.tsx
@@ -3,7 +3,6 @@ import { ConfirmationModal } from '../../components/modals/confirmation.modal';
 import { TextInput } from '../../components/input/textInput';
 import { DishesRepositoryImpl } from '../../../network/repositories/dishes.repository';
 import { CardsRepositoryImpl } from '../../../network/repositories/cards.repository';
-import { useAlerts } from '../../../contexts/alerts.context';
 import { Dish } from '../../../data/models/dish.model';
 import { CardDto } from '../../../data/dto/card.dto';
 import { CircularProgress } from '@mui/material';
@@ -33,7 +32,6 @@ export const EditCardModal: React.FC<EditCardModalProps> = ({
     const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
     const [error, setError] = useState('');
     
-    const { addAlert } = useAlerts();
     const dishesRepository = new DishesRepositoryImpl();
     const cardsRepository = new CardsRepositoryImpl();
 

--- a/src/UI/pages/dishes/dishes.page.tsx
+++ b/src/UI/pages/dishes/dishes.page.tsx
@@ -48,7 +48,7 @@ export default function DishesPage() {
     };
 
     fetch();
-  }, []);
+  }, [dishRepository]);
 
   useEffect(() => {
     let result = [...dishes];


### PR DESCRIPTION
## Summary
- clean up EditCardModal by removing unused `addAlert`
- load dishes when dish repository changes on DishesPage

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af2b05704832aa567838ac9a374b0