### PR TITLE
Refactor hooks out of context files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,8 @@ import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 import AlertsProvider from './contexts/alerts.context';
 import AuthProvider from './contexts/auth.provider';
 import SettingsPage from './UI/pages/settings/settings.page';
-import { ThemeProvider, useTheme } from './contexts/theme.context';
+import { ThemeProvider } from './contexts/theme.context';
+import { useTheme } from './hooks/theme.hook';
 
 const ThemedApp = () => {
   const { isDarkMode } = useTheme();

--- a/src/UI/components/forms/dish/dish.form.tsx
+++ b/src/UI/components/forms/dish/dish.form.tsx
@@ -10,7 +10,7 @@ import { NumberInput } from "../../../components/input/number.input";
 import { CircularProgress } from "@mui/material";
 import { DishesRepositoryImpl } from "../../../../network/repositories/dishes.repository";
 import { DishCategory, DishCategoryLabels } from "../../../../data/dto/dish.dto";
-import { useAlerts } from "../../../../contexts/alerts.context";
+import { useAlerts } from "../../../../hooks/alerts.hook";
 import { DishIngredientCreationDto } from "../../../../data/dto/dish.creation.dto";
 import { DishFormProps, DishFormMode } from "./dish.form.props";
 

--- a/src/UI/components/navigationBar/navigation.bar.tsx
+++ b/src/UI/components/navigationBar/navigation.bar.tsx
@@ -9,7 +9,7 @@ import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import TuneRoundedIcon from '@mui/icons-material/TuneRounded';
 import { Fragment, useEffect } from 'react';
 import { useUsersListerDispatchContext, useUsersListerStateContext } from '../../../reducers/auth.reducer';
-import { useAlerts } from '../../../contexts/alerts.context';
+import { useAlerts } from '../../../hooks/alerts.hook';
 import FirebaseAuthManager from '../../../network/authentication/firebase.auth.manager';
 import { UserRepositoryImpl } from '../../../network/repositories/user.respository';
 

--- a/src/UI/components/settingsContent/preferencesContent.tsx
+++ b/src/UI/components/settingsContent/preferencesContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTheme } from '../../../contexts/theme.context';
+import { useTheme } from '../../../hooks/theme.hook';
 import { Moon, Sun } from 'lucide-react';
 
 export const PreferencesContent: React.FC = () => {

--- a/src/UI/components/settingsContent/profilContent.tsx
+++ b/src/UI/components/settingsContent/profilContent.tsx
@@ -3,7 +3,7 @@ import { useUsersListerDispatchContext, useUsersListerStateContext } from '../..
 import { UserRepositoryImpl } from '../../../network/repositories/user.respository';
 import CustomButton, { TypeButton, WidthButton } from '../buttons/custom.button';
 import { useState } from 'react';
-import { useAlerts } from '../../../contexts/alerts.context';
+import { useAlerts } from '../../../hooks/alerts.hook';
 
 export const ProfilContent: React.FC = () => {
     const dispatch = useUsersListerDispatchContext();

--- a/src/UI/components/tables/dishes/dish.row.tsx
+++ b/src/UI/components/tables/dishes/dish.row.tsx
@@ -5,7 +5,7 @@ import { DishRowProps } from "./dish.props";
 import { useState } from "react";
 import { ConfirmationModal } from "../../modals/confirmation.modal";
 import { DishesRepositoryImpl } from "../../../../network/repositories/dishes.repository";
-import { useAlerts } from "../../../../contexts/alerts.context";
+import { useAlerts } from "../../../../hooks/alerts.hook";
 import { DishCategoryLabels } from "../../../../data/dto/dish.dto";
 
 const categoryColors: Record<string, { bg: string; text: string }> = {

--- a/src/UI/pages/authentication/login.page.tsx
+++ b/src/UI/pages/authentication/login.page.tsx
@@ -3,7 +3,7 @@ import { TextInput } from "../../components/input/textInput";
 import TitleStyle from "../../style/title.style";
 import CustomButton, { TypeButton, WidthButton } from "../../components/buttons/custom.button";
 import { UserRepositoryImpl } from '../../../network/repositories/user.respository';
-import { useAlerts } from '../../../contexts/alerts.context';
+import { useAlerts } from '../../../hooks/alerts.hook';
 import { BaseContent } from '../../components/contents/base.content';
 
 

--- a/src/UI/pages/cards/cards.page.tsx
+++ b/src/UI/pages/cards/cards.page.tsx
@@ -3,7 +3,7 @@ import { BaseContent } from '../../components/contents/base.content';
 import TitleStyle from '../../style/title.style';
 import { CardDto } from '../../../data/dto/card.dto';
 import { CardsRepositoryImpl } from '../../../network/repositories/cards.repository';
-import { useAlerts } from '../../../contexts/alerts.context';
+import { useAlerts } from '../../../hooks/alerts.hook';
 import { CircularProgress } from '@mui/material';
 import { CreateCardModal } from './create.card.modal';
 import { PanelContent } from '../../components/contents/panel.content';

--- a/src/UI/pages/cards/create.card.modal.tsx
+++ b/src/UI/pages/cards/create.card.modal.tsx
@@ -3,7 +3,7 @@ import { ConfirmationModal } from '../../components/modals/confirmation.modal';
 import { TextInput } from '../../components/input/textInput';
 import { DishesRepositoryImpl } from '../../../network/repositories/dishes.repository';
 import { CardsRepositoryImpl } from '../../../network/repositories/cards.repository';
-import { useAlerts } from '../../../contexts/alerts.context';
+import { useAlerts } from '../../../hooks/alerts.hook';
 import { Dish } from '../../../data/models/dish.model';
 import { CardDto } from '../../../data/dto/card.dto';
 import { CircularProgress } from '@mui/material';

--- a/src/UI/pages/dashboard/dashboard.page.tsx
+++ b/src/UI/pages/dashboard/dashboard.page.tsx
@@ -4,7 +4,7 @@ import { PanelContent } from '../../components/contents/panel.content';
 import TitleStyle from '../../style/title.style';
 import { DishesRepositoryImpl } from '../../../network/repositories/dishes.repository';
 import { CardsRepositoryImpl } from '../../../network/repositories/cards.repository';
-import { useAlerts } from '../../../contexts/alerts.context';
+import { useAlerts } from '../../../hooks/alerts.hook';
 import { Dish } from '../../../data/models/dish.model';
 import { CircularProgress } from '@mui/material';
 import { 

--- a/src/UI/pages/dish/dish.page.tsx
+++ b/src/UI/pages/dish/dish.page.tsx
@@ -6,7 +6,7 @@ import { CircularProgress } from '@mui/material';
 import { SearchInput } from '../../components/input/searchInput';
 import TextfieldList from '../../components/input/textfield.list';
 import { DishesRepositoryImpl } from '../../../network/repositories/dishes.repository';
-import { useAlerts } from '../../../contexts/alerts.context';
+import { useAlerts } from '../../../hooks/alerts.hook';
 import { Dish } from '../../../data/models/dish.model';
 import DishesTable from '../../components/tables/dishes/dish.table';
 import UpdateDishPage from './update.dish.page';

--- a/src/UI/pages/dishes/dishes.page.tsx
+++ b/src/UI/pages/dishes/dishes.page.tsx
@@ -6,7 +6,7 @@ import { CircularProgress } from '@mui/material';
 import { SearchInput } from '../../components/input/searchInput';
 import TextfieldList from '../../components/input/textfield.list';
 import { DishesRepositoryImpl } from '../../../network/repositories/dishes.repository';
-import { useAlerts } from '../../../contexts/alerts.context';
+import { useAlerts } from '../../../hooks/alerts.hook';
 import { Dish } from '../../../data/models/dish.model';
 import DishesTable from '../../components/tables/dishes/dish.table';
 import UpdateDishPage from './update.dish.page';

--- a/src/contexts/alerts.context.tsx
+++ b/src/contexts/alerts.context.tsx
@@ -1,8 +1,8 @@
-import { createContext, useContext, useRef, useState, ReactNode, FC } from "react";
+import { createContext, useState, ReactNode, FC } from "react";
 import { Alert, AlertsWrapper } from "../UI/components/alert/alert";
 
 // Définition du type de l'alerte
-interface AlertType {
+export interface AlertType {
   id?: string;
   message: string;
   severity?: 'info' | 'warning' | 'error' | 'success';
@@ -16,7 +16,7 @@ interface AlertsContextType {
   dismissAlert: (id: string) => void;
 }
 
-const AlertsContext = createContext<AlertsContextType | undefined>(undefined);
+export const AlertsContext = createContext<AlertsContextType | undefined>(undefined);
 
 // Composant AlertsProvider
 const AlertsProvider: FC<{children: ReactNode}> = ({ children }) => {
@@ -42,33 +42,6 @@ const AlertsProvider: FC<{children: ReactNode}> = ({ children }) => {
       {children}
     </AlertsContext.Provider>
   );
-}
-
-// Hook useAlerts
-export const useAlerts = () => {
-  const context = useContext(AlertsContext);
-  if (!context) {
-    throw new Error('useAlerts must be used within an AlertsProvider');
-  }
-
-  const { addAlert, dismissAlert } = context;
-
-  const [alertIds, setAlertIds] = useState<string[]>([]);
-  const alertIdsRef = useRef<string[]>(alertIds);
-
-  const addAlertWithId = (alert: Omit<AlertType, 'id'>): void => {
-    const id = addAlert(alert);
-    alertIdsRef.current.push(id);
-    setAlertIds([...alertIdsRef.current]);
-  }
-
-  const clearAlerts = (): void => {
-    alertIdsRef.current.forEach(dismissAlert);
-    alertIdsRef.current = [];
-    setAlertIds([]);
-  }
-
-  return { addAlert: addAlertWithId, clearAlerts };
 }
 
 export default AlertsProvider;

--- a/src/contexts/theme.context.tsx
+++ b/src/contexts/theme.context.tsx
@@ -1,19 +1,11 @@
-import React, { createContext, useContext, ReactNode, useState } from 'react';
+import React, { createContext, ReactNode, useState } from 'react';
 
 interface ThemeContextType {
   isDarkMode: boolean;
   toggleTheme: () => void;
 }
 
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
-
-export const useTheme = () => {
-  const context = useContext(ThemeContext);
-  if (context === undefined) {
-    throw new Error('useTheme doit être utilisé au sein d’un ThemeProvider');
-  }
-  return context;
-};
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     const [isDarkMode, setIsDarkMode] = useState(() => {

--- a/src/hooks/alerts.hook.ts
+++ b/src/hooks/alerts.hook.ts
@@ -1,0 +1,28 @@
+import { useContext, useRef, useState } from 'react';
+import { AlertsContext, AlertType } from '../contexts/alerts.context';
+
+export const useAlerts = () => {
+  const context = useContext(AlertsContext);
+  if (!context) {
+    throw new Error('useAlerts must be used within an AlertsProvider');
+  }
+
+  const { addAlert, dismissAlert } = context;
+
+  const [alertIds, setAlertIds] = useState<string[]>([]);
+  const alertIdsRef = useRef<string[]>(alertIds);
+
+  const addAlertWithId = (alert: Omit<AlertType, 'id'>): void => {
+    const id = addAlert(alert);
+    alertIdsRef.current.push(id);
+    setAlertIds([...alertIdsRef.current]);
+  };
+
+  const clearAlerts = (): void => {
+    alertIdsRef.current.forEach(dismissAlert);
+    alertIdsRef.current = [];
+    setAlertIds([]);
+  };
+
+  return { addAlert: addAlertWithId, clearAlerts };
+};

--- a/src/hooks/theme.hook.ts
+++ b/src/hooks/theme.hook.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../contexts/theme.context';
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme doit être utilisé au sein d\u2019un ThemeProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- create standalone alerts and theme hooks
- export contexts from existing provider files
- update imports to use new hooks

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afdaaf7e0832a967812522653b342