### PR TITLE
Move ESLint to flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,32 @@
+import js from '@eslint/js';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  js.configs.recommended,
+  tsPlugin.configs.recommended,
+  reactHooks.configs.recommended,
+  {
+    ignores: ['dist', '.eslintrc.cjs'],
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      globals: {
+        ...js.environments.browser.globals,
+        ...js.environments.es2020.globals,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 15",
+    "lint": "eslint --config eslint.config.js . --ext ts,tsx --report-unused-disable-directives --max-warnings 15",
     "preview": "vite preview",
     "test": "vitest"
   },


### PR DESCRIPTION
## Summary
- add `eslint.config.js` with settings from `.eslintrc.cjs`
- point the `lint` script at the new config file

## Testing
- `npm run lint --silent` *(fails: Cannot find package)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684affad6bf0832a91bbeb894905b311