### PR TITLE
Memoize repositories

### DIFF
--- a/src/UI/pages/dashboard/dashboard.page.tsx
+++ b/src/UI/pages/dashboard/dashboard.page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { BaseContent } from '../../components/contents/base.content';
 import { PanelContent } from '../../components/contents/panel.content';
 import TitleStyle from '../../style/title.style';
@@ -34,8 +34,8 @@ export default function DashboardPage() {
   const [recentDishes, setRecentDishes] = useState<Dish[]>([]);
   const { addAlert } = useAlerts();
   
-  const dishesRepository = new DishesRepositoryImpl();
-  const cardsRepository = new CardsRepositoryImpl();
+  const dishesRepository = useMemo(() => new DishesRepositoryImpl(), []);
+  const cardsRepository = useMemo(() => new CardsRepositoryImpl(), []);
 
   useEffect(() => {
     const fetchDashboardData = async () => {

--- a/src/UI/pages/dishes/dishes.page.tsx
+++ b/src/UI/pages/dishes/dishes.page.tsx
@@ -1,7 +1,7 @@
 import DrawerButton, { ContainerDrawer } from '../../components/drawer';
 import TitleStyle from '../../style/title.style';
 import AddDishPage from './add.dish.page';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { CircularProgress } from '@mui/material';
 import { SearchInput } from '../../components/input/searchInput';
 import TextfieldList from '../../components/input/textfield.list';
@@ -25,7 +25,7 @@ export default function DishesPage() {
   const [selectedCategory, setSelectedCategory] = useState<string>('Toutes');
   const [selectedStatus, setSelectedStatus] = useState<string>('Tous');
   const { addAlert } = useAlerts();
-  const dishRepository = new DishesRepositoryImpl();
+  const dishRepository = useMemo(() => new DishesRepositoryImpl(), []);
 
   const statusOptions = ['Tous', 'Actif', 'Inactif'];
   const categoryOptions = ['Toutes', ...Object.values(DishCategoryLabels)];
@@ -48,7 +48,7 @@ export default function DishesPage() {
     };
 
     fetch();
-  }, [fetchDishes]);
+  }, [fetchDishes, dishRepository]);
 
   useEffect(() => {
     let result = [...dishes];


### PR DESCRIPTION
## Summary
- use `useMemo` to create repository instances in DashboardPage and DishesPage
- update hooks to use the memoized repositories

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b35a6b744832aa93dbb80e31fc083