### PR TITLE
Fix card update payload

### DIFF
--- a/src/UI/pages/cards/edit.card.modal.tsx
+++ b/src/UI/pages/cards/edit.card.modal.tsx
@@ -105,7 +105,8 @@ export const EditCardModal: React.FC<EditCardModalProps> = ({
                 _id: card._id,
                 name: name.trim(),
                 dishesId: Array.from(selectedDishes),
-                isActive: card.isActive
+                isActive: card.isActive,
+                dateOfCreation: card.dateOfCreation
             });
             
             onCardUpdated(updatedCard);


### PR DESCRIPTION
## Summary
- keep original dateOfCreation when editing a card

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b390bbc70832a8504521dea3fa53b