### PR TITLE
Fix typed props in modal input style

### DIFF
--- a/src/UI/style/modal.input.style.tsx
+++ b/src/UI/style/modal.input.style.tsx
@@ -5,7 +5,7 @@ interface ModalInputProps {
     type?: 'text' | 'number';
 }
 
-const ModalInput = styled.input<ModalInputProps>(() => [
+const ModalInput = styled.input<ModalInputProps>(({ type }) => [
     tw`
         font-inter
     `,
@@ -22,7 +22,7 @@ const ModalInput = styled.input<ModalInputProps>(() => [
         cursor: text;
         padding: 3px 6px;
         height: 28px;
-        ${({ type }) => type === 'number' && css`
+        ${type === 'number' && css`
         &::-webkit-outer-spin-button,
         &::-webkit-inner-spin-button {
          -webkit-appearance: none;


### PR DESCRIPTION
## Summary
- type styled input props in modal.input.style.tsx

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b3e86f178832a97b34598eee58af3