### PR TITLE
Fix table pagination and modal portal usage

### DIFF
--- a/src/UI/components/modals/confirmation.modal.tsx
+++ b/src/UI/components/modals/confirmation.modal.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useEffect } from "react";
+import { createPortal } from "react-dom";
 import CloseIcon from '@mui/icons-material/Close';
 
 interface ConfirmationModalProps {
@@ -42,10 +43,10 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
         }
     };
 
-    return (
-        <dialog 
-            id={modalName} 
-            className="modal" 
+    const dialog = (
+        <dialog
+            id={modalName}
+            className="modal"
             onClick={handleBackdropClick}
         >
             <div className="modal-box p-0 max-w-md" onClick={e => e.stopPropagation()}>
@@ -61,4 +62,6 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
             </div>
         </dialog>
     );
+
+    return createPortal(dialog, document.body);
 };

--- a/src/UI/components/tables/dishes/dish.table.tsx
+++ b/src/UI/components/tables/dishes/dish.table.tsx
@@ -119,21 +119,16 @@ const DishesTable: React.FC<DishesTableProps> = ({ dishes, setSelectedDish, onDe
           )}
           </TableBody>
           <TableFooter>
-          <TableRow>
-              <TableCell colSpan={6}>
-                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                  <TablePagination
-                    sx={{ borderBottom: 0 }}
-                    rowsPerPageOptions={[10]}
-                    colSpan={3}
-                    count={reversedDishes.length}
-                    rowsPerPage={10}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    ActionsComponent={TablePaginationActions}
-                  />
-                </Box>
-              </TableCell>
+            <TableRow>
+              <TablePagination
+                sx={{ borderBottom: 0, ml: 'auto' }}
+                rowsPerPageOptions={[10]}
+                count={reversedDishes.length}
+                rowsPerPage={10}
+                page={page}
+                onPageChange={handleChangePage}
+                ActionsComponent={TablePaginationActions}
+              />
             </TableRow>
           </TableFooter>
         </Table>


### PR DESCRIPTION
## Summary
- mount confirmation modals in a portal attached to document body
- render table pagination directly within TableRow without extra TableCell/Box

## Testing
- `npm run lint`
- `npm test` *(fails to exit, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684b4946e77c832a89a5ba7e5dc77b76