### PR TITLE
Prevent hooks from recreating resources

### DIFF
--- a/src/UI/components/navigationBar/navigation.bar.tsx
+++ b/src/UI/components/navigationBar/navigation.bar.tsx
@@ -7,14 +7,14 @@ import LocalDiningRoundedIcon from '@mui/icons-material/LocalDiningRounded';
 import InventoryRoundedIcon from '@mui/icons-material/InventoryRounded';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import TuneRoundedIcon from '@mui/icons-material/TuneRounded';
-import { Fragment, useEffect } from 'react';
+import { Fragment, useEffect, useMemo } from 'react';
 import { useUsersListerDispatchContext, useUsersListerStateContext } from '../../../reducers/auth.reducer';
 import { useAlerts } from '../../../hooks/alerts.hook';
 import FirebaseAuthManager from '../../../network/authentication/firebase.auth.manager';
 import { UserRepositoryImpl } from '../../../network/repositories/user.respository';
 
 export function NavBar() {
-    const userRepository = new UserRepositoryImpl()
+    const userRepository = useMemo(() => new UserRepositoryImpl(), [])
     const { addAlert } = useAlerts();
     const dispatch = useUsersListerDispatchContext();
 

--- a/src/contexts/alerts.context.tsx
+++ b/src/contexts/alerts.context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState, ReactNode, FC } from "react";
+import { createContext, useState, ReactNode, FC, useCallback } from "react";
 import { Alert, AlertsWrapper } from "../UI/components/alert/alert";
 
 // Définition du type de l'alerte
@@ -22,15 +22,15 @@ export const AlertsContext = createContext<AlertsContextType | undefined>(undefi
 const AlertsProvider: FC<{children: ReactNode}> = ({ children }) => {
   const [alerts, setAlerts] = useState<AlertType[]>([]);
 
-  const addAlert = (alert: Omit<AlertType, 'id'>): string => {
+  const addAlert = useCallback((alert: Omit<AlertType, 'id'>): string => {
     const id = Math.random().toString(36).slice(2, 9) + new Date().getTime().toString(36);
     setAlerts((prev) => [{ ...alert, id: id }, ...prev]);
     return id;
-  }
+  }, []);
 
-  const dismissAlert = (id: string): void => {
+  const dismissAlert = useCallback((id: string): void => {
     setAlerts((prev) => prev.filter((alert) => alert.id !== id));
-  }
+  }, []);
 
   return (
     <AlertsContext.Provider value={{ alerts, addAlert, dismissAlert }}>


### PR DESCRIPTION
## Summary
- stabilize alert handlers with useCallback
- memoize user repository in NavBar so it doesn't rerun every render

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b4deafd28832a9b1c1c92be732966