### PR TITLE
Support ReactNode alert messages

### DIFF
--- a/src/UI/components/alert/alert.tsx
+++ b/src/UI/components/alert/alert.tsx
@@ -3,13 +3,13 @@ import { classNames, svgFillColors, svgPaths } from "./severity-styles";
 
 // Définition des types pour les props de Alert
 interface AlertProps {
-  message?: string;
+  message?: ReactNode;
   severity?: 'info' | 'warning' | 'error' | 'success'; // Supposons que ce sont vos seules valeurs possibles pour severity
   timeout?: number;
   handleDismiss?: () => void;
 }
 
-const Alert: React.FC<AlertProps> = ({ message = '', severity = 'info', timeout = 0, handleDismiss = null }) => {
+const Alert: React.FC<AlertProps> = ({ message = null, severity = 'info', timeout = 0, handleDismiss = null }) => {
   useEffect(() => {
     if (timeout > 0 && handleDismiss) {
       const timer = setTimeout(() => {
@@ -26,7 +26,12 @@ const Alert: React.FC<AlertProps> = ({ message = '', severity = 'info', timeout 
     }
   };
 
-  return message?.length ? (
+  const isMessageEmpty =
+    message === null ||
+    message === undefined ||
+    (typeof message === 'string' && message.trim().length === 0);
+
+  return !isMessageEmpty ? (
     <div className={classNames[severity] + " rounded-b px-4 py-3 mb-4 shadow-md pointer-events-auto"} role="alert">
       <div className="flex">
         <div className="py-1">

--- a/src/contexts/alerts.context.tsx
+++ b/src/contexts/alerts.context.tsx
@@ -4,7 +4,7 @@ import { Alert, AlertsWrapper } from "../UI/components/alert/alert";
 // Définition du type de l'alerte
 interface AlertType {
   id?: string;
-  message: string;
+  message: ReactNode;
   severity?: 'info' | 'warning' | 'error' | 'success';
   timeout?: number;
 }

--- a/src/tests/alert.test.tsx
+++ b/src/tests/alert.test.tsx
@@ -3,15 +3,17 @@ import { Alert, AlertsWrapper } from '../UI/components/alert/alert';
 import { describe, test, expect, vi } from 'vitest';
 
 describe('Alert Component', () => {
-  test('renders alert with message and severity', () => {
+  test('renders alert with JSX message and severity', () => {
     render(
       <Alert
-        message="Test message"
+        message={<span data-testid="jsx-msg"><strong>Test</strong> message</span>}
         severity="info"
       />
     );
 
-    expect(screen.getByText('Test message')).toBeInTheDocument();
+    const msgEl = screen.getByTestId('jsx-msg');
+    expect(msgEl).toBeInTheDocument();
+    expect(msgEl.textContent).toBe('Test message');
     expect(screen.getByText('INFO')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- allow `AlertProps` and `AlertType` messages to accept any `ReactNode`
- update `Alert` rendering logic for node messages
- test passing JSX fragments as messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bfd9ca434832ab2602b958d7b2056