### PR TITLE
Add alert persistence

### DIFF
--- a/src/contexts/alerts.context.tsx
+++ b/src/contexts/alerts.context.tsx
@@ -9,6 +9,7 @@ export interface AlertType {
   severity?: 'info' | 'warning' | 'error' | 'success';
   timeout?: number;
   priority?: number;
+  persist?: boolean;
 }
 
 // Définition du type pour le contexte
@@ -29,16 +30,56 @@ const defaultDurations: Record<'info' | 'warning' | 'error' | 'success', number>
 
 // Composant AlertsProvider
 const MAX_VISIBLE_ALERTS = 3;
+const STORAGE_KEY = 'persistedAlerts';
+
+const loadPersistedAlerts = (): AlertType[] => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) as AlertType[] : [];
+  } catch {
+    return [];
+  }
+};
+
+const savePersistedAlerts = (alerts: AlertType[]): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(alerts));
+};
+
+const addPersistedAlert = (alert: AlertType): void => {
+  const stored = loadPersistedAlerts();
+  savePersistedAlerts([...stored, alert]);
+};
+
+const removePersistedAlert = (id: string): void => {
+  const stored = loadPersistedAlerts();
+  const updated = stored.filter(a => a.id !== id);
+  savePersistedAlerts(updated);
+};
 
 const AlertsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [alerts, setAlerts] = useState<AlertType[]>([]);
   const [queue, setQueue] = useState<AlertType[]>([]);
 
+  // load persisted alerts on mount
+  useEffect(() => {
+    const persisted = loadPersistedAlerts();
+    if (persisted.length > 0) {
+      const visible = persisted.slice(0, MAX_VISIBLE_ALERTS);
+      const queued = persisted.slice(MAX_VISIBLE_ALERTS);
+      setAlerts(visible);
+      setQueue(queued);
+    }
+  }, []);
+
   const addAlert = (alert: Omit<AlertType, 'id'>): string => {
     const id = crypto.randomUUID();
     const timeout = alert.timeout ?? defaultDurations[alert.severity ?? 'info'];
     const priority = alert.priority ?? 0;
-    const newAlert = { ...alert, id, timeout, priority };
+    const newAlert: AlertType = { ...alert, id, timeout, priority };
+
+    if (newAlert.persist) {
+      addPersistedAlert(newAlert);
+    }
 
     if (alerts.length < MAX_VISIBLE_ALERTS) {
       setAlerts((prev) => [newAlert, ...prev]);
@@ -54,7 +95,13 @@ const AlertsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   };
 
   const dismissAlert = (id: string): void => {
-    setAlerts((prev) => prev.filter((alert) => alert.id !== id));
+    setAlerts((prev) => {
+      const toRemove = prev.find(a => a.id === id);
+      if (toRemove?.persist) {
+        removePersistedAlert(id);
+      }
+      return prev.filter((alert) => alert.id !== id);
+    });
   };
 
   // When space is available, move alerts from the queue

--- a/src/tests/alerts.context.test.tsx
+++ b/src/tests/alerts.context.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AlertsProvider, { useAlerts } from '../contexts/alerts.context';
+import { describe, test, expect, beforeEach } from 'vitest';
+
+const TestComponent = () => {
+  const { addAlert } = useAlerts();
+  return <button onClick={() => addAlert({ message: 'persisted', persist: true })}>add</button>;
+};
+
+describe('AlertsProvider persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('stores alert in localStorage when persist is true', () => {
+    render(
+      <AlertsProvider>
+        <TestComponent />
+      </AlertsProvider>
+    );
+
+    fireEvent.click(screen.getByText('add'));
+    const stored = JSON.parse(localStorage.getItem('persistedAlerts') || '[]');
+    expect(stored.length).toBe(1);
+    expect(stored[0].message).toBe('persisted');
+  });
+
+  test('loads persisted alerts on init', () => {
+    const alert = { id: '1', message: 'hello', severity: 'info', timeout: 5, priority: 0, persist: true };
+    localStorage.setItem('persistedAlerts', JSON.stringify([alert]));
+
+    render(
+      <AlertsProvider>
+        <div />
+      </AlertsProvider>
+    );
+
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  test('removes persisted alert from storage when dismissed', () => {
+    const alert = { id: '1', message: 'bye', severity: 'info', timeout: 5, priority: 0, persist: true };
+    localStorage.setItem('persistedAlerts', JSON.stringify([alert]));
+
+    render(
+      <AlertsProvider>
+        <div />
+      </AlertsProvider>
+    );
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    const stored = JSON.parse(localStorage.getItem('persistedAlerts') || '[]');
+    expect(stored.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `persist` option on `AlertType`
- save persisted alerts to localStorage
- load saved alerts on provider mount and remove them on dismiss
- test alert persistence features

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684c18ad7d90832abdfa61083d67726b