### PR TITLE
Implement grouped alerts

### DIFF
--- a/src/tests/alerts.context.test.tsx
+++ b/src/tests/alerts.context.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import AlertsProvider, { useAlerts } from '../contexts/alerts.context';
 import { describe, test, expect, beforeEach } from 'vitest';
 
@@ -53,5 +53,57 @@ describe('AlertsProvider persistence', () => {
 
     const stored = JSON.parse(localStorage.getItem('persistedAlerts') || '[]');
     expect(stored.length).toBe(0);
+  });
+
+  test('updates alert when same groupId is added', () => {
+    const GroupComp = () => {
+      const { addAlert } = useAlerts();
+      return (
+        <>
+          <button onClick={() => addAlert({ message: 'first', groupId: 'g1' })}>first</button>
+          <button onClick={() => addAlert({ message: 'second', groupId: 'g1' })}>second</button>
+        </>
+      );
+    };
+
+    render(
+      <AlertsProvider>
+        <GroupComp />
+      </AlertsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'first' }));
+    let alertEl = screen.getByRole('alert');
+    expect(within(alertEl).getByText('first')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'second' }));
+    alertEl = screen.getByRole('alert');
+    expect(within(alertEl).queryByText('first')).toBeNull();
+    expect(within(alertEl).getByText('second')).toBeInTheDocument();
+  });
+
+  test('persisted alert updates when using the same groupId', () => {
+    const PersistComp = () => {
+      const { addAlert } = useAlerts();
+      return (
+        <>
+          <button onClick={() => addAlert({ message: 'p1', groupId: 'gp', persist: true })}>one</button>
+          <button onClick={() => addAlert({ message: 'p2', groupId: 'gp', persist: true })}>two</button>
+        </>
+      );
+    };
+
+    render(
+      <AlertsProvider>
+        <PersistComp />
+      </AlertsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'one' }));
+    fireEvent.click(screen.getByRole('button', { name: 'two' }));
+
+    const stored = JSON.parse(localStorage.getItem('persistedAlerts') || '[]');
+    expect(stored.length).toBe(1);
+    expect(stored[0].message).toBe('p2');
   });
 });


### PR DESCRIPTION
## Summary
- extend `AlertType` with `groupId`
- update alert creation logic to update existing alerts with the same `groupId`
- persist grouped alerts correctly
- add tests for grouped alert behaviour

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684c1b128ea4832ab1a23226ac04c31b