### PR TITLE
Add aria-live to alert wrapper

### DIFF
--- a/src/UI/components/alert/alert.tsx
+++ b/src/UI/components/alert/alert.tsx
@@ -64,7 +64,11 @@ interface AlertsWrapperProps {
 
 const AlertsWrapper: React.FC<AlertsWrapperProps> = ({ children }) => {
   return (
-    <div className="fixed top-0 right-0 p-4 z-[100] pointer-events-none max-w-sm min-w-fit w-full">
+    <div
+      className="fixed top-0 right-0 p-4 z-[100] pointer-events-none max-w-sm min-w-fit w-full"
+      role="alert"
+      aria-live="assertive"
+    >
       {children}
     </div>
   );

--- a/src/tests/alert.test.tsx
+++ b/src/tests/alert.test.tsx
@@ -85,6 +85,8 @@ describe('AlertsWrapper Component', () => {
       </AlertsWrapper>
     );
 
+    const wrapper = screen.getByRole('alert');
+    expect(wrapper).toHaveAttribute('aria-live', 'assertive');
     expect(screen.getByTestId('test-child')).toBeInTheDocument();
     expect(screen.getByText('Test Child')).toBeInTheDocument();
   });

--- a/src/tests/alerts.context.test.tsx
+++ b/src/tests/alerts.context.test.tsx
@@ -73,11 +73,11 @@ describe('AlertsProvider persistence', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'first' }));
-    let alertEl = screen.getByRole('alert');
+    let alertEl = screen.getAllByRole('alert')[1];
     expect(within(alertEl).getByText('first')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'second' }));
-    alertEl = screen.getByRole('alert');
+    alertEl = screen.getAllByRole('alert')[1];
     expect(within(alertEl).queryByText('first')).toBeNull();
     expect(within(alertEl).getByText('second')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- update `AlertsWrapper` markup so the wrapper div has `role="alert"` and `aria-live="assertive"`
- adjust tests for wrapper to check accessibility attributes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c1f5fa3fc832aa71bfc8bc4fbf53b