### PR TITLE
Add dish creation date sorting

### DIFF
--- a/src/UI/pages/dishes/utils/filterDishes.ts
+++ b/src/UI/pages/dishes/utils/filterDishes.ts
@@ -1,0 +1,33 @@
+import { Dish } from '../../../../data/models/dish.model';
+import { DishCategory } from '../../../../data/dto/dish.dto';
+
+export interface FilterOptions {
+  searchQuery: string;
+  selectedCategory: DishCategory | 'Toutes';
+  selectedStatus: 'Tous' | 'Actif' | 'Inactif';
+}
+
+export function filterDishes(dishes: Dish[], options: FilterOptions): Dish[] {
+  let result = [...dishes];
+  const { searchQuery, selectedCategory, selectedStatus } = options;
+
+  if (searchQuery) {
+    const lower = searchQuery.toLowerCase();
+    result = result.filter(
+      (dish) =>
+        dish.name.toLowerCase().includes(lower) ||
+        dish.description.toLowerCase().includes(lower)
+    );
+  }
+
+  if (selectedCategory !== 'Toutes') {
+    result = result.filter((dish) => dish.category === selectedCategory);
+  }
+
+  if (selectedStatus !== 'Tous') {
+    const isActive = selectedStatus === 'Actif';
+    result = result.filter((dish) => dish.isAvailable === isActive);
+  }
+
+  return result;
+}

--- a/src/UI/pages/dishes/utils/sortDishes.ts
+++ b/src/UI/pages/dishes/utils/sortDishes.ts
@@ -1,0 +1,37 @@
+export type DishSortOption =
+  | 'Nom (Ascendant)'
+  | 'Nom (Descendant)'
+  | 'Prix (Ascendant)'
+  | 'Prix (Descendant)'
+  | 'Date de création (Ascendant)'
+  | 'Date de création (Descendant)';
+
+import { Dish } from '../../../../data/models/dish.model';
+
+export function sortDishes(dishes: Dish[], option: DishSortOption): Dish[] {
+  const copy = [...dishes];
+  switch (option) {
+    case 'Nom (Ascendant)':
+      return copy.sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+      );
+    case 'Nom (Descendant)':
+      return copy.sort((a, b) =>
+        b.name.localeCompare(a.name, undefined, { sensitivity: 'base' })
+      );
+    case 'Prix (Ascendant)':
+      return copy.sort((a, b) => a.price - b.price);
+    case 'Prix (Descendant)':
+      return copy.sort((a, b) => b.price - a.price);
+    case 'Date de création (Ascendant)':
+      return copy.sort(
+        (a, b) => new Date(a.dateOfCreation).getTime() - new Date(b.dateOfCreation).getTime()
+      );
+    case 'Date de création (Descendant)':
+      return copy.sort(
+        (a, b) => new Date(b.dateOfCreation).getTime() - new Date(a.dateOfCreation).getTime()
+      );
+    default:
+      return copy;
+  }
+}

--- a/src/data/dto/dish.dto.ts
+++ b/src/data/dto/dish.dto.ts
@@ -34,6 +34,7 @@ export interface DishDto {
   price: number;
   description: string;
   category: DishCategory;
+  dateOfCreation: string;
   timeCook?: number;
   isAvailable: boolean;
 }

--- a/src/data/models/dish.model.ts
+++ b/src/data/models/dish.model.ts
@@ -8,6 +8,7 @@ export class Dish {
   price: number;
   description: string;
   category: DishCategory;
+  dateOfCreation: string;
   timeCook?: number;
   isAvailable: boolean;
 
@@ -18,6 +19,7 @@ export class Dish {
     price: number,
     description: string,
     category: DishCategory,
+    dateOfCreation: string,
     isAvailable: boolean,
     timeCook?: number
   ) {
@@ -27,6 +29,7 @@ export class Dish {
     this.price = price;
     this.description = description;
     this.category = category;
+    this.dateOfCreation = dateOfCreation;
     this.timeCook = timeCook;
     this.isAvailable = isAvailable;
   }
@@ -46,6 +49,7 @@ export class Dish {
       dto.price,
       dto.description,
       dto.category,
+      dto.dateOfCreation,
       dto.isAvailable,
       dto.timeCook
     );

--- a/src/tests/dishes.utils.test.ts
+++ b/src/tests/dishes.utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { sortDishes } from '../UI/pages/dishes/utils/sortDishes';
+import { filterDishes } from '../UI/pages/dishes/utils/filterDishes';
+import { Dish } from '../data/models/dish.model';
+import { DishCategory } from '../data/dto/dish.dto';
+
+const dishes: Dish[] = [
+  new Dish('1', 'Burger', [], 12, 'desc', DishCategory.MAIN_DISHES, '2024-01-01T00:00:00Z', true),
+  new Dish('2', 'Apple Pie', [], 8, 'desc', DishCategory.DESSERTS, '2024-03-01T00:00:00Z', false),
+  new Dish('3', 'Caesar', [], 10, 'desc', DishCategory.SALADS, '2023-12-01T00:00:00Z', true)
+];
+
+describe('sortDishes', () => {
+  it('sorts by name ascending', () => {
+    const result = sortDishes(dishes, 'Nom (Ascendant)');
+    expect(result[0].name).toBe('Apple Pie');
+    expect(result[2].name).toBe('Caesar');
+  });
+
+  it('sorts by price descending', () => {
+    const result = sortDishes(dishes, 'Prix (Descendant)');
+    expect(result[0].price).toBe(12);
+    expect(result[2].price).toBe(8);
+  });
+
+  it('sorts by creation date ascending', () => {
+    const result = sortDishes(dishes, 'Date de création (Ascendant)');
+    expect(result[0].dateOfCreation).toBe('2023-12-01T00:00:00Z');
+    expect(result[2].dateOfCreation).toBe('2024-03-01T00:00:00Z');
+  });
+});
+
+describe('filterDishes', () => {
+  it('filters by search query and category and status', () => {
+    const result = filterDishes(dishes, {
+      searchQuery: 'a',
+      selectedCategory: DishCategory.DESSERTS,
+      selectedStatus: 'Inactif'
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].name).toBe('Apple Pie');
+  });
+});


### PR DESCRIPTION
## Summary
- include `dateOfCreation` in `DishDto` and `Dish` model
- add `filterDishes` and `sortDishes` utilities
- refactor dishes page to use new utils and default sorting by creation date
- test the filtering and sorting utilities

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fe80bcbf4832ab4903651d0651151